### PR TITLE
CD to Divshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.divshot-cache

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ deployment:
   development:
     branch: /feature.*/
     commands:
-      - npm install ember-cli-divshot
+      - npm install -g ember-cli-divshot
       - ember divshot push development --token $DIVSHOT_TOKEN
 
 
   staging:
     branch: develop
     commands:
-      - npm install ember-cli-divshot
+      - npm install -g ember-cli-divshot
       - ember divshot push staging --token $DIVSHOT_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+deployment:
+  staging:
+    branch: develop
+    commands:
+      - npm install ember-cli-divshot
+      - ember divshot push staging --token $DIVSHOT_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,9 @@ deployment:
     commands:
       - npm install -g ember-cli ember-cli-divshot
       - ember divshot push staging --token $DIVSHOT_TOKEN
+
+  production:
+    branch: master
+    commands:
+      - npm install -g ember-cli ember-cli-divshot
+      - ember divshot push master --token $DIVSHOT_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,11 @@
 deployment:
+  development:
+    branch: /feature.*/
+    commands:
+      - npm install ember-cli-divshot
+      - ember divshot push development --token $DIVSHOT_TOKEN
+
+
   staging:
     branch: develop
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,4 @@
 deployment:
-  development:
-    branch: /feature.*/
-    commands:
-      - npm install -g ember-cli ember-cli-divshot
-      - ember divshot push development --token $DIVSHOT_TOKEN
-
-
   staging:
     branch: develop
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ deployment:
   development:
     branch: /feature.*/
     commands:
-      - npm install -g ember-cli-divshot
+      - npm install -g ember-cli ember-cli-divshot
       - ember divshot push development --token $DIVSHOT_TOKEN
 
 
   staging:
     branch: develop
     commands:
-      - npm install -g ember-cli-divshot
+      - npm install -g ember-cli ember-cli-divshot
       - ember divshot push staging --token $DIVSHOT_TOKEN

--- a/divshot.json
+++ b/divshot.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-getting-started",
+  "root": "./dist",
+  "routes": {
+    "/tests": "tests/index.html",
+    "/tests/**": "tests/index.html",
+    "/**": "index.html"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-divshot": "^0.1.7",
     "ember-cli-dotenv": "0.3.4",
     "ember-cli-foundation-sass": "^1.0.0",
     "ember-cli-htmlbars": "^0.6.0",


### PR DESCRIPTION
Closes #11 

See:
- http://docs.divshot.com/integrations/circleci
- https://github.com/rwjblue/ember-cli-divshot

The idea is to let CircleCI run `ember-cli-divshot` when something hits `develop`, then push the build up onto Divshot with the `DIVSHOT_TOKEN` I've already added to the CircleCI environment variables
- [x] CD to divshot
- [x] Make sure env variables get added – thanks for helping out with this one @catkins! 
