### PR TITLE
Fix distorted google map controls

### DIFF
--- a/app/styles/components/_googleMap.scss
+++ b/app/styles/components/_googleMap.scss
@@ -7,4 +7,8 @@
   min-height: 600px;
   height: 100vh;
   width: 100%;
+
+  & img {
+    max-width: none;
+  }
 }


### PR DESCRIPTION
Closes #13 

Removed `max-width: 100%` on the google map controls, as that was distorting the sprite.
